### PR TITLE
Add text field to BoardSelector

### DIFF
--- a/src/components/BoardSelector.vue
+++ b/src/components/BoardSelector.vue
@@ -18,9 +18,7 @@
       @focus="($event.target as HTMLInputElement).select()"
       @change="onBoardTextChange"
     />
-    <button class="button-base button-blue" @click="clearBoard">
-      Clear
-    </button>
+    <button class="button-base button-blue" @click="clearBoard">Clear</button>
     <button class="button-base button-blue" @click="generateRandomBoard">
       Random Flop
     </button>
@@ -42,7 +40,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useConfigStore } from "../store";
-import { cardText, parseCardString, ranks, suitLetters } from "../utils";
+import { cardText, parseCardString } from "../utils";
 import BoardSelectorCard from "./BoardSelectorCard.vue";
 
 const config = useConfigStore();
@@ -65,29 +63,29 @@ const setBoardTextFromButtons = () => {
   const cards = config.board
     .map(cardText)
     .map(({ rank, suitLetter }) => rank + suitLetter)
-    .join(', ');
+    .join(", ");
   boardText.value = cards;
-}
+};
 
 const onBoardTextChange = () => {
   config.board = [];
 
   const cardIds = boardText.value
     // Allow pasting in things like [Ah Kd Qc], by reformatting to Ah,Kd,Qc
-    .replace(/[^a-zA-Z0-9\s,]/g, '')
-    .replace(/\s+/g, ',')
-    .split(',')
-    .map(s => s.trim())
+    .replace(/[^a-zA-Z0-9\s,]/g, "")
+    .replace(/\s+/g, ",")
+    .split(",")
+    .map((s) => s.trim())
     .map(parseCardString)
-    .filter(cardId => Number.isInteger(cardId));
+    .filter((cardId) => Number.isInteger(cardId));
 
-  new Set(cardIds).forEach(cardId => toggleCard(cardId!));
-}
+  new Set(cardIds).forEach((cardId) => toggleCard(cardId as number));
+};
 
 const clearBoard = () => {
   config.board = [];
   setBoardTextFromButtons();
-}
+};
 
 const generateRandomBoard = () => {
   config.board = [];

--- a/src/components/ResultChance.vue
+++ b/src/components/ResultChance.vue
@@ -51,7 +51,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { ranks, suits, toFixed1, toFixedAdaptive } from "../utils";
+import { cardId, ranks, suits, toFixed1, toFixedAdaptive } from "../utils";
 import {
   ChanceReports,
   Spot,
@@ -147,7 +147,7 @@ const chartData = computed((): ChartData<"bar", number[]> | null => {
         if (action.amount !== "0") label += ` ${action.amount}`;
         return {
           data: Array.from({ length: 13 }, (_, rank) => {
-            const card = 4 * rank + suit;
+            const card = cardId(rank, suit);
             if (reports.status[card] === 0) return 0;
             const coef = isCombos ? reports.combos[playerIndex][card] : 1;
             return coef * reports.strategy[actionIndex * 52 + card];
@@ -161,7 +161,7 @@ const chartData = computed((): ChartData<"bar", number[]> | null => {
     } else {
       datasets = Array.from({ length: 4 }, (_, suit) => ({
         data: Array.from({ length: 13 }, (_, rank) => {
-          const card = 4 * rank + suit;
+          const card = cardId(rank, suit);
           if (reports.status[card] === 0) return 0;
           return isCombos ? reports.combos[playerIndex][card] : 1;
         }).reverse(),

--- a/src/components/ResultTable.vue
+++ b/src/components/ResultTable.vue
@@ -356,6 +356,7 @@ import {
   toFixed,
   toFixedAdaptive,
   capitalize,
+  suitLetters,
 } from "../utils";
 
 import {
@@ -463,11 +464,9 @@ const columnIndex = (column: Column) => {
 const yellow500 = "#eab308";
 const neutral800 = "#262626";
 
-const suits = ["c", "d", "h", "s"];
-
 const cardStr = (card: number) => {
   const rank = ranks[card >>> 2];
-  const suit = suits[card & 3];
+  const suit = suitLetters[card & 3];
   return rank + suit;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,10 @@ export const cardId = (rank: number, suit: number) => {
 };
 
 export const parseCardString = (text: string) => {
-  const pattern = new RegExp(`^([${ranks.join(' ')}])([${suitLetters.join(' ')}])$`, 'i');
+  const pattern = new RegExp(
+    `^([${ranks.join(" ")}])([${suitLetters.join(" ")}])$`,
+    "i"
+  );
   const match = text.match(pattern);
   if (!match) return null;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@ export const ranks = [
 ];
 
 export const suits = ["♣", "♦", "♥", "♠"];
+export const suitLetters = ["c", "d", "h", "s"];
 
 const rankPat = "[AaKkQqJjTt2-9]";
 const comboPat = `(?:(?:${rankPat}{2}[os]?)|(?:(?:${rankPat}[cdhs]){2}))`;
@@ -35,8 +36,23 @@ export const cardText = (card: number) => {
   return {
     rank: ranks[card >>> 2],
     suit: suits[card & 3],
+    suitLetter: suitLetters[card & 3],
     colorClass: suitClasses[card & 3],
   };
+};
+
+export const cardId = (rank: number, suit: number) => {
+  return 4 * rank + suit;
+};
+
+export const parseCardString = (text: string) => {
+  const pattern = new RegExp(`^([${ranks.join(' ')}])([${suitLetters.join(' ')}])$`, 'i');
+  const match = text.match(pattern);
+  if (!match) return null;
+
+  const rank = ranks.indexOf(match[1].toUpperCase());
+  const suit = suitLetters.indexOf(match[2].toLowerCase());
+  return cardId(rank, suit);
 };
 
 export const cardPairCellIndex = (card1: number, card2: number) => {


### PR DESCRIPTION
to allow quick pasting in of flop cards from other tools

Considerations when defocusing the input:
- the loading of cards into the model is done by clearing the board and through the existing toggleCard function, so that handles the 5 card limitation
- text is parsed and loaded into the model. the text is then regenerated from the model to ensure correct formatting
- if you type non-letter symbols (other than comma or space), they are stripped, to allow easy pasting of data from other programs
- if you type invalid cards, they are simply ignored and removed from the input
- cards are case insensitive. as per point 2, they are correctly capitalized automatically

Toggling cards via the buttons of course updates the input

![image](https://github.com/b-inary/desktop-postflop/assets/17482349/3d2a25e6-2646-4e41-a986-cb60524a075f)
