### PR TITLE
Add json import

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -24,6 +24,9 @@
           </div>
         </div>
 
+        <div v-show="store.sideView === 'hand-importer'">
+          <HandImporter />
+        </div>
         <div v-show="store.sideView === 'oop-range'">
           <RangeEditor :player="0" />
         </div>
@@ -70,6 +73,7 @@ import BunchingEffect from "./BunchingEffect.vue";
 import RunSolver from "./RunSolver.vue";
 import AboutPage from "./AboutPage.vue";
 import ResultViewer from "./ResultViewer.vue";
+import HandImporter from "./HandImporter.vue";
 
 const store = useStore();
 const header = computed(() => store.headers[store.sideView].join(" > "));

--- a/src/components/BoardSelector.vue
+++ b/src/components/BoardSelector.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { useConfigStore } from "../store";
 import { cardText, parseCardString } from "../utils";
 import BoardSelectorCard from "./BoardSelectorCard.vue";
@@ -46,7 +46,13 @@ import BoardSelectorCard from "./BoardSelectorCard.vue";
 const config = useConfigStore();
 const boardText = ref("");
 
-const toggleCard = (cardId: number, updateText = true) => {
+watch(
+  () => config.board,
+  () => setBoardTextFromButtons(),
+  { deep: true }
+);
+
+const toggleCard = (cardId: number) => {
   if (config.board.includes(cardId)) {
     config.board = config.board.filter((card) => card !== cardId);
   } else if (config.board.length < 5) {
@@ -54,10 +60,6 @@ const toggleCard = (cardId: number, updateText = true) => {
     if (config.board.length <= 3) {
       config.board.sort((a, b) => b - a);
     }
-  }
-
-  if (updateText) {
-    setBoardTextFromButtons();
   }
 };
 
@@ -80,13 +82,11 @@ const onBoardTextChange = () => {
     .map(parseCardString)
     .filter((cardId): cardId is number => cardId !== null);
 
-  new Set(cardIds).forEach((cardId) => toggleCard(cardId, false));
-  setBoardTextFromButtons();
+  new Set(cardIds).forEach((cardId) => toggleCard(cardId));
 };
 
 const clearBoard = () => {
   config.board = [];
-  setBoardTextFromButtons();
 };
 
 const generateRandomBoard = () => {
@@ -100,6 +100,5 @@ const generateRandomBoard = () => {
   }
 
   config.board.sort((a, b) => b - a);
-  setBoardTextFromButtons();
 };
 </script>

--- a/src/components/BunchingEffect.vue
+++ b/src/components/BunchingEffect.vue
@@ -202,7 +202,8 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useStore, useConfigStore } from "../store";
-import { trimRegex, rangeRegex, cardText } from "../utils";
+import { cardText } from "../utils";
+import { trimRegex, rangeRegex } from "../range-utils";
 import * as invokes from "../invokes";
 
 import RangeEditor from "./RangeEditor.vue";

--- a/src/components/BunchingEffect.vue
+++ b/src/components/BunchingEffect.vue
@@ -202,8 +202,8 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useStore, useConfigStore } from "../store";
-import { cardText } from "../utils";
-import { trimRegex, rangeRegex } from "../range-utils";
+import { cardText, trimRegex } from "../utils";
+import { rangeRegex } from "../range-utils";
 import * as invokes from "../invokes";
 
 import RangeEditor from "./RangeEditor.vue";

--- a/src/components/HandImporter.vue
+++ b/src/components/HandImporter.vue
@@ -1,0 +1,195 @@
+<template>
+  <div class="mt-1 w-[52rem]">
+    <textarea
+      v-model="importText"
+      class="block w-full h-[36rem] px-2 py-1 rounded-lg textarea text-sm font-mono"
+      @change="onImportTextChanged"
+      spellcheck="false"
+    />
+
+    <div class="w-full">
+      <button class="button-base button-blue mt-3 mr-3" @click="importHand">
+        Import
+      </button>
+      <span v-if="importDoneText" class="mt-1">{{ importDoneText }}</span>
+      <span v-if="importTextError" class="mt-1 text-red-500">
+        {{ 'Error: ' + importTextError }}
+      </span>
+    </div>
+
+    <div class="mt-2">
+      Note: If the import has missing values, the current value will be used.
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import { Config, configKeys, useConfigStore, useStore } from "../store";
+import { cardText, parseCardString, Position, Validation } from "../utils";
+import { setRange, validateRange } from "../range-utils";
+import * as invokes from "../invokes";
+
+type NonValidatedHandJSON = Record<string, any>;
+type HandJSON = {
+  oopRange: string;
+  ipRange: string;
+  config: Omit<Config, "board"> & { board: string[] };
+};
+
+const INVALID_BOARD_ERROR = `Invalid '.config.board'. Set board cards manually for an example.`;
+
+const config = useConfigStore();
+const store = useStore();
+
+const importText = ref("{\n  \n}");
+const importTextError = ref("");
+const importDoneText = ref("");
+
+watch(
+  () => store.ranges,
+  () => generateImportText(),
+  { deep: true }
+);
+watch(
+  () => Object.values(config),
+  () => generateImportText(),
+  { deep: true }
+);
+
+const generateImportText = async () => {
+  const configObj = Object.fromEntries(
+    Object.entries(config).filter(
+      ([key, _value]) => configKeys.indexOf(key) !== -1
+    )
+  );
+
+  const importObj = {
+    oopRange: await invokes.rangeToString(Position.OOP),
+    ipRange: await invokes.rangeToString(Position.IP),
+    config: {
+      ...configObj,
+      board: config.board.map((cardId) => {
+        const { rank, suitLetter } = cardText(cardId);
+        return rank + suitLetter;
+      }),
+    },
+  };
+
+  importText.value = JSON.stringify(importObj, null, 2);
+};
+
+const onImportTextChanged = () => {
+  importDoneText.value = "";
+  validateImportTextAndDisplayError();
+};
+
+const validateConfigPrimitives = (importConfig: any): Validation => {
+  if (typeof importConfig !== "object")
+    return {
+      success: false,
+      error: `Expected '.config' to be an object but got ${typeof importConfig}`,
+    };
+
+  for (const key of configKeys) {
+    const newValue = importConfig[key];
+    const existingValue = (config as any)[key];
+    if (existingValue === null || existingValue === undefined) continue;
+    if (typeof existingValue === typeof newValue) continue;
+
+    if (key === "board") return { success: false, error: INVALID_BOARD_ERROR };
+    else
+      return {
+        success: false,
+        error: `Expected '.config.${key}' to be ${typeof importConfig} but got ${typeof newValue}`,
+      };
+  }
+
+  return { success: true };
+};
+
+const validateBoard = (board: any): Validation => {
+  if (!Array.isArray(board))
+    return { success: false, error: INVALID_BOARD_ERROR };
+  const boardArr = board as any[];
+
+  for (const i in boardArr) {
+    const card = boardArr[i];
+    if (typeof card !== "string") {
+      return { success: false, error: INVALID_BOARD_ERROR };
+    }
+
+    const parsedCard = parseCardString(card);
+    if (parsedCard === null) {
+      return { success: false, error: INVALID_BOARD_ERROR };
+    }
+  }
+
+  return { success: true };
+};
+
+const parseJson = (
+  json: string
+): Validation<{ json?: NonValidatedHandJSON }> => {
+  try {
+    return { success: true, json: JSON.parse(json) };
+  } catch (e) {
+    const message = (e as Error).message;
+    return { success: false, error: message };
+  }
+};
+
+const validateImportTextAndDisplayError = (): Validation<{
+  json?: HandJSON;
+}> => {
+  importTextError.value = "";
+
+  const validation = validateImportText();
+  if (validation.success) return validation;
+
+  importTextError.value = validation.error as string;
+  return validation;
+};
+
+const validateImportText = (): Validation<{ json?: HandJSON }> => {
+  const parseValidation = parseJson(importText.value);
+  if (!parseValidation.success) return parseValidation;
+
+  const importJson = parseValidation.json;
+  if (typeof importJson !== "object")
+    return { success: false, error: "Not a valid JSON object" };
+
+  const validateFns: (() => Validation)[] = [
+    () => validateConfigPrimitives(config),
+    () => validateBoard(importJson.config?.board),
+    () => validateRange(importJson.oopRange, "oopRange"),
+    () => validateRange(importJson.ipRange, "ipRange"),
+  ];
+  for (const validate of validateFns) {
+    const validation = validate();
+    if (!validation.success) return validation;
+  }
+
+  importJson.config.board = importJson.config.board.map(parseCardString);
+
+  return { success: true, json: importJson as HandJSON };
+};
+
+const importHand = async () => {
+  const validation = validateImportTextAndDisplayError();
+  if (!validation.success) return;
+  const importJson = validation.json as HandJSON;
+
+  for (const key in importJson.config) {
+    const newValue = (importJson.config as Record<string, any>)[key];
+    (config as any)[key] = newValue;
+  }
+
+  await setRange(Position.OOP, importJson.oopRange, store);
+  await setRange(Position.IP, importJson.ipRange, store);
+
+  importDoneText.value = "Done!";
+};
+
+generateImportText();
+</script>

--- a/src/components/HandImporter.vue
+++ b/src/components/HandImporter.vue
@@ -77,6 +77,8 @@ const generateImportText = async () => {
   };
 
   importText.value = JSON.stringify(importObj, null, 2);
+  importTextError.value = '';
+  importDoneText.value = '';
 };
 
 const onImportTextChanged = () => {

--- a/src/components/HandImporter.vue
+++ b/src/components/HandImporter.vue
@@ -39,6 +39,8 @@ type HandJSON = {
 
 const INVALID_BOARD_ERROR = `Invalid '.config.board'. Set board cards manually for an example.`;
 
+const CONFIG_INPUT_KEYS = configKeys.filter(k => ['expectedBoardLength'].indexOf(k) === -1);
+
 const config = useConfigStore();
 const store = useStore();
 
@@ -60,7 +62,7 @@ watch(
 const generateImportText = async () => {
   const configObj = Object.fromEntries(
     Object.entries(config).filter(
-      ([key, _value]) => configKeys.indexOf(key) !== -1
+      ([key, _value]) => CONFIG_INPUT_KEYS.indexOf(key) !== -1
     )
   );
 
@@ -93,10 +95,9 @@ const validateConfigPrimitives = (importConfig: any): Result => {
       error: `Expected '.config' to be an object but got ${typeof importConfig}`,
     };
 
-  for (const key of configKeys.concat(Object.keys(importConfig))) {
+  for (const key of CONFIG_INPUT_KEYS.concat(Object.keys(importConfig))) {
     const newValue = importConfig[key];
     const existingValue = (config as any)[key];
-    console.log({ key, existingValue, newValue })
 
     if (existingValue === undefined) {
       return { success: false, error: `Unexpected key '.config.${key}'` };
@@ -129,6 +130,10 @@ const validateBoard = (board: any): Result => {
     if (parsedCard === null) {
       return { success: false, error: INVALID_BOARD_ERROR };
     }
+  }
+
+  if (board.length > 5) {
+    return { success: false, error: 'Board cannot have more than 5 cards' };
   }
 
   return { success: true };
@@ -177,6 +182,7 @@ const validateImportText = (): Result<{ json?: HandJSON }> => {
   }
 
   importJson.config.board = importJson.config.board.map(parseCardString);
+  importJson.config.expectedBoardLength = importJson.config.board.length;
 
   return { success: true, json: importJson as HandJSON };
 };

--- a/src/components/HandImporter.vue
+++ b/src/components/HandImporter.vue
@@ -2,7 +2,7 @@
   <div class="mt-1 w-[52rem]">
     <textarea
       v-model="importText"
-      class="block w-full h-[36rem] px-2 py-1 rounded-lg textarea text-sm font-mono"
+      :class='"block w-full h-[36rem] px-2 py-1 rounded-lg textarea text-sm font-mono " + (importTextError ? "textarea-error" : "")'
       @change="onImportTextChanged"
       spellcheck="false"
     />

--- a/src/components/HandImporter.vue
+++ b/src/components/HandImporter.vue
@@ -93,17 +93,22 @@ const validateConfigPrimitives = (importConfig: any): Result => {
       error: `Expected '.config' to be an object but got ${typeof importConfig}`,
     };
 
-  for (const key of configKeys) {
+  for (const key of configKeys.concat(Object.keys(importConfig))) {
     const newValue = importConfig[key];
     const existingValue = (config as any)[key];
-    if (existingValue === null || existingValue === undefined) continue;
+    console.log({ key, existingValue, newValue })
+
+    if (existingValue === undefined) {
+      return { success: false, error: `Unexpected key '.config.${key}'` };
+    }
+
     if (typeof existingValue === typeof newValue) continue;
 
     if (key === "board") return { success: false, error: INVALID_BOARD_ERROR };
     else
       return {
         success: false,
-        error: `Expected '.config.${key}' to be ${typeof importConfig} but got ${typeof newValue}`,
+        error: `Expected '.config.${key}' to be ${typeof existingValue} but got ${typeof newValue}`,
       };
   }
 
@@ -161,7 +166,7 @@ const validateImportText = (): Result<{ json?: HandJSON }> => {
     return { success: false, error: "Not a valid JSON object" };
 
   const validateFns: (() => Result)[] = [
-    () => validateConfigPrimitives(config),
+    () => validateConfigPrimitives(importJson.config),
     () => validateBoard(importJson.config?.board),
     () => validateRange(importJson.oopRange, "oopRange"),
     () => validateRange(importJson.ipRange, "ipRange"),

--- a/src/components/HandImporter.vue
+++ b/src/components/HandImporter.vue
@@ -26,7 +26,7 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
 import { Config, configKeys, useConfigStore, useStore } from "../store";
-import { cardText, parseCardString, Position, Validation } from "../utils";
+import { cardText, parseCardString, Position, Result } from "../utils";
 import { setRange, validateRange } from "../range-utils";
 import * as invokes from "../invokes";
 
@@ -86,7 +86,7 @@ const onImportTextChanged = () => {
   validateImportTextAndDisplayError();
 };
 
-const validateConfigPrimitives = (importConfig: any): Validation => {
+const validateConfigPrimitives = (importConfig: any): Result => {
   if (typeof importConfig !== "object")
     return {
       success: false,
@@ -110,13 +110,12 @@ const validateConfigPrimitives = (importConfig: any): Validation => {
   return { success: true };
 };
 
-const validateBoard = (board: any): Validation => {
+const validateBoard = (board: any): Result => {
   if (!Array.isArray(board))
     return { success: false, error: INVALID_BOARD_ERROR };
-  const boardArr = board as any[];
 
-  for (const i in boardArr) {
-    const card = boardArr[i];
+  for (const i in board) {
+    const card = board[i];
     if (typeof card !== "string") {
       return { success: false, error: INVALID_BOARD_ERROR };
     }
@@ -132,7 +131,7 @@ const validateBoard = (board: any): Validation => {
 
 const parseJson = (
   json: string
-): Validation<{ json?: NonValidatedHandJSON }> => {
+): Result<{ json?: NonValidatedHandJSON }> => {
   try {
     return { success: true, json: JSON.parse(json) };
   } catch (e) {
@@ -141,7 +140,7 @@ const parseJson = (
   }
 };
 
-const validateImportTextAndDisplayError = (): Validation<{
+const validateImportTextAndDisplayError = (): Result<{
   json?: HandJSON;
 }> => {
   importTextError.value = "";
@@ -153,7 +152,7 @@ const validateImportTextAndDisplayError = (): Validation<{
   return validation;
 };
 
-const validateImportText = (): Validation<{ json?: HandJSON }> => {
+const validateImportText = (): Result<{ json?: HandJSON }> => {
   const parseValidation = parseJson(importText.value);
   if (!parseValidation.success) return parseValidation;
 
@@ -161,7 +160,7 @@ const validateImportText = (): Validation<{ json?: HandJSON }> => {
   if (typeof importJson !== "object")
     return { success: false, error: "Not a valid JSON object" };
 
-  const validateFns: (() => Validation)[] = [
+  const validateFns: (() => Result)[] = [
     () => validateConfigPrimitives(config),
     () => validateBoard(importJson.config?.board),
     () => validateRange(importJson.oopRange, "oopRange"),

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,19 +1,26 @@
 <template>
   <aside class="flex flex-col shrink-0 w-56 my-4 overflow-y-auto border-r-2">
     <button
+      :class="itemStyle('hand-importer')"
+      @click="store.sideView = 'hand-importer'"
+    >
+      Import / Export
+    </button>
+
+    <button
       :class="itemStyle('oop-range')"
       @click="store.sideView = 'oop-range'"
     >
       OOP Range
       <span class="flex my-2 justify-center">
-        <RangeMiniViewer :player="0" />
+        <RangeMiniViewer :player="Position.OOP" />
       </span>
     </button>
 
     <button :class="itemStyle('ip-range')" @click="store.sideView = 'ip-range'">
       IP Range
       <span class="flex my-2 justify-center">
-        <RangeMiniViewer :player="1" />
+        <RangeMiniViewer :player="Position.IP" />
       </span>
     </button>
 
@@ -59,7 +66,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { SideView, useStore, useConfigStore } from "../store";
-import { cardText } from "../utils";
+import { Position, cardText } from "../utils";
 
 import RangeMiniViewer from "./RangeMiniViewer.vue";
 

--- a/src/components/TreeConfig.vue
+++ b/src/components/TreeConfig.vue
@@ -749,6 +749,7 @@ import {
   ROOT_LINE_STRING,
   INVALID_LINE_STRING,
   readableLineString,
+  getExpectedBoardLength,
 } from "../utils";
 
 import DbItemPicker from "./DbItemPicker.vue";
@@ -1067,9 +1068,11 @@ const saveEdit = (addedLines: string, removedLines: string) => {
   isEditMode.value = false;
   config.addedLines = addedLines;
   config.removedLines = removedLines;
-  if (config.addedLines === "" && config.removedLines === "") {
-    config.expectedBoardLength = 0;
-  }
+  config.expectedBoardLength = getExpectedBoardLength(
+    config.board.length,
+    addedLines,
+    removedLines
+  );
   store.headers["tree-config"].pop();
 };
 

--- a/src/range-utils.ts
+++ b/src/range-utils.ts
@@ -1,0 +1,67 @@
+import { Position, Validation } from "./utils";
+import * as invokes from "./invokes";
+import { useStore } from "./store";
+
+type Store = ReturnType<typeof useStore>;
+
+const rankPat = "[AaKkQqJjTt2-9]";
+const comboPat = `(?:(?:${rankPat}{2}[os]?)|(?:(?:${rankPat}[cdhs]){2}))`;
+const weightPat = "(?:(?:[01](\\.\\d*)?)|(?:\\.\\d+))";
+export const trimRegex = /\s*([-:,])\s*/g;
+export const rangeRegex = new RegExp(
+  `^(?<range>${comboPat}(?:\\+|(?:-${comboPat}))?)(?::(?<weight>${weightPat}))?$`
+);
+
+const trimRange = (rangeString: string) =>
+  rangeString.replace(trimRegex, "$1").trim();
+
+export const validateRange = (
+  rangeString: any,
+  keyForError = "range"
+): Validation => {
+  if (typeof rangeString !== "string")
+    return {
+      success: false,
+      error: `Expected '${keyForError}' to be a string but got '${typeof rangeString}`,
+    };
+
+  const trimmed = trimRange(rangeString);
+  const ranges = trimmed.split(",");
+
+  if (ranges[ranges.length - 1] === "") ranges.pop();
+
+  for (const range of ranges) {
+    if (!rangeRegex.test(range)) {
+      return {
+        success: false,
+        error: `'${range}' is not a valid range. For an example of a valid range, assign a range manually.`,
+      };
+    }
+  }
+
+  return { success: true };
+};
+
+export const setRange = async (
+  player: Position,
+  rangeString: string,
+  store: Store
+): Promise<Validation> => {
+  const trimmed = rangeString.replace(trimRegex, "$1").trim();
+  const validation = validateRange(rangeString);
+  if (!validation.success) return validation;
+
+  const error = await invokes.rangeFromString(player, trimmed);
+  if (error) return { success: false, error };
+
+  await loadRangeToStore(player, store);
+
+  return { success: true };
+};
+
+const loadRangeToStore = async (player: number, store: Store) => {
+  const weights = await invokes.rangeGetWeights(player);
+  for (let i = 0; i < 13 * 13; ++i) {
+    store.ranges[player][i] = weights[i] * 100;
+  }
+};

--- a/src/range-utils.ts
+++ b/src/range-utils.ts
@@ -1,13 +1,10 @@
-import { Position, Validation } from "./utils";
+import { Position, Validation, trimRegex, comboPat } from "./utils";
 import * as invokes from "./invokes";
 import { useStore } from "./store";
 
 type Store = ReturnType<typeof useStore>;
 
-const rankPat = "[AaKkQqJjTt2-9]";
-const comboPat = `(?:(?:${rankPat}{2}[os]?)|(?:(?:${rankPat}[cdhs]){2}))`;
-const weightPat = "(?:(?:[01](\\.\\d*)?)|(?:\\.\\d+))";
-export const trimRegex = /\s*([-:,])\s*/g;
+export const weightPat = "(?:(?:[01](\\.\\d*)?)|(?:\\.\\d+))";
 export const rangeRegex = new RegExp(
   `^(?<range>${comboPat}(?:\\+|(?:-${comboPat}))?)(?::(?<weight>${weightPat}))?$`
 );

--- a/src/range-utils.ts
+++ b/src/range-utils.ts
@@ -1,4 +1,4 @@
-import { Position, Validation, trimRegex, comboPat } from "./utils";
+import { Position, Result, trimRegex, comboPat } from "./utils";
 import * as invokes from "./invokes";
 import { useStore } from "./store";
 
@@ -15,7 +15,7 @@ const trimRange = (rangeString: string) =>
 export const validateRange = (
   rangeString: any,
   keyForError = "range"
-): Validation => {
+): Result => {
   if (typeof rangeString !== "string")
     return {
       success: false,
@@ -43,7 +43,7 @@ export const setRange = async (
   player: Position,
   rangeString: string,
   store: Store
-): Promise<Validation> => {
+): Promise<Result> => {
   const trimmed = rangeString.replace(trimRegex, "$1").trim();
   const validation = validateRange(rangeString);
   if (!validation.success) return validation;

--- a/src/range-utils.ts
+++ b/src/range-utils.ts
@@ -13,7 +13,7 @@ const trimRange = (rangeString: string) =>
   rangeString.replace(trimRegex, "$1").trim();
 
 export const validateRange = (
-  rangeString: any,
+  rangeString: unknown | string,
   keyForError = "range"
 ): Result => {
   if (typeof rangeString !== "string")

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,7 @@ import { sanitizeBetString } from "./utils";
 export type NavView = "solver" | "results";
 
 export type SideView =
+  | "hand-importer"
   | "oop-range"
   | "ip-range"
   | "board"
@@ -11,6 +12,64 @@ export type SideView =
   | "bunching"
   | "run-solver"
   | "about";
+
+export type Config = {
+  board: number[];
+  startingPot: number;
+  effectiveStack: number;
+  rakePercent: number;
+  rakeCap: number;
+  donkOption: boolean;
+  oopFlopBet: string;
+  oopFlopRaise: string;
+  oopTurnBet: string;
+  oopTurnRaise: string;
+  oopTurnDonk: string;
+  oopRiverBet: string;
+  oopRiverRaise: string;
+  oopRiverDonk: string;
+  ipFlopBet: string;
+  ipFlopRaise: string;
+  ipTurnBet: string;
+  ipTurnRaise: string;
+  ipRiverBet: string;
+  ipRiverRaise: string;
+  addAllInThreshold: number;
+  forceAllInThreshold: number;
+  mergingThreshold: number;
+  expectedBoardLength: number;
+  addedLines: string;
+  removedLines: string;
+};
+
+export const configKeys = [
+  "board",
+  "startingPot",
+  "effectiveStack",
+  "rakePercent",
+  "rakeCap",
+  "donkOption",
+  "oopFlopBet",
+  "oopFlopRaise",
+  "oopTurnBet",
+  "oopTurnRaise",
+  "oopTurnDonk",
+  "oopRiverBet",
+  "oopRiverRaise",
+  "oopRiverDonk",
+  "ipFlopBet",
+  "ipFlopRaise",
+  "ipTurnBet",
+  "ipTurnRaise",
+  "ipRiverBet",
+  "ipRiverRaise",
+  "addAllInThreshold",
+  "forceAllInThreshold",
+  "mergingThreshold",
+  "expectedBoardLength",
+  "addedLines",
+  "removedLines",
+];
 
 export const saveConfigTmp = () => {
   const config = useConfigStore();
@@ -86,6 +145,7 @@ export const useStore = defineStore("app", {
     sideView: "oop-range" as SideView,
     headers: {
       about: ["About"],
+      "hand-importer": ["Import / Export"],
       "oop-range": ["OOP Range"],
       "ip-range": ["IP Range"],
       board: ["Board"],
@@ -120,7 +180,7 @@ export const useStore = defineStore("app", {
 });
 
 export const useConfigStore = defineStore("config", {
-  state: () => ({
+  state: (): Config => ({
     board: [] as number[],
     startingPot: 20,
     effectiveStack: 100,

--- a/src/style.css
+++ b/src/style.css
@@ -36,6 +36,10 @@ input.input-error {
   @apply !ring-1 !ring-red-600 !border-red-600 !bg-red-50;
 }
 
+textarea.textarea-error {
+  @apply !ring-1 !ring-red-600 !border-red-600 !bg-red-50;
+}
+
 .text-shadow {
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,8 @@
+// TODO clean up types with generitc type and casts
+export type Validation<Contents = {}> =
+  | ({ success: true } & Contents)
+  | { success: false; error: string };
+
 export const ranks = [
   "2",
   "3",
@@ -25,6 +30,12 @@ export const trimRegex = /\s*([-:,])\s*/g;
 export const rangeRegex = new RegExp(
   `^(?<range>${comboPat}(?:\\+|(?:-${comboPat}))?)(?::(?<weight>${weightPat}))?$`
 );
+
+/** TODO use this everywhere instead of num */
+export enum Position {
+  OOP = 0,
+  IP = 1,
+}
 
 const suitClasses = [
   "text-green-600",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-export type Result<Contents = {}> =
+export type Result<Contents = object> =
   | ({ success: true } & Contents)
   | { success: false; error: string };
 
@@ -345,4 +345,13 @@ export const readableLineString = (s: string): string => {
   }
 
   return ret;
+};
+
+export const getExpectedBoardLength = (
+  boardLength: number,
+  addedLines: string,
+  removedLines: string
+) => {
+  if (addedLines === "" && removedLines === "") return 0;
+  return Math.max(boardLength, 3);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
-// TODO clean up types with generitc type and casts
-export type Validation<Contents = {}> =
+export type Result<Contents = {}> =
   | ({ success: true } & Contents)
   | { success: false; error: string };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,14 +22,10 @@ export const ranks = [
 export const suits = ["♣", "♦", "♥", "♠"];
 export const suitLetters = ["c", "d", "h", "s"];
 
-const rankPat = "[AaKkQqJjTt2-9]";
-const comboPat = `(?:(?:${rankPat}{2}[os]?)|(?:(?:${rankPat}[cdhs]){2}))`;
-const weightPat = "(?:(?:[01](\\.\\d*)?)|(?:\\.\\d+))";
-const cardRegex = new RegExp(`^(${rankPat})([cdhs])$`);
+export const rankPat = "[AaKkQqJjTt2-9]";
+export const comboPat = `(?:(?:${rankPat}{2}[os]?)|(?:(?:${rankPat}[cdhs]){2}))`;
+export const cardRegex = new RegExp(`^(${rankPat})([cdhs])$`);
 export const trimRegex = /\s*([-:,])\s*/g;
-export const rangeRegex = new RegExp(
-  `^(?<range>${comboPat}(?:\\+|(?:-${comboPat}))?)(?::(?<weight>${weightPat}))?$`
-);
 
 /** TODO use this everywhere instead of num */
 export enum Position {


### PR DESCRIPTION
![image](https://github.com/b-inary/desktop-postflop/assets/17482349/83e853a8-815d-43b6-bccd-30cf32b35fae)

Added JSON import/export page.
- the user can paste in some json to set the ranges/board/tree config.
  - this is to allow external tools to generate the json for a quick input
- the json is automatically updated whenever any range/board/tree config is changed. for easy export

requires #31 to be merged first, as this is branched off that
fixes https://github.com/b-inary/wasm-postflop/issues/17